### PR TITLE
Initial implementation of greedy solver with fallback logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,15 @@ target_include_directories(common
 )
 # target_link_libraries(common PUBLIC OpenMP::OpenMP_CXX)
 
+# —————— Greedy Solver ——————
+add_library(greedy_solver STATIC
+        src/greedy-solver/greedy.cpp
+)
+target_include_directories(greedy_solver PUBLIC
+        ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(greedy_solver PUBLIC common)
+
 # —————— Generator ——————
 add_executable(generator
         src/generator/main.cpp
@@ -48,24 +57,6 @@ set_target_properties(generator PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin
 )
 
-# —————— Greedy Solver ——————
-add_executable(greedy_solver
-        src/greedy-solver/greedy.cpp
-        include/greedy-solver/greedy.hpp
-
-)
-target_include_directories(greedy_solver
-        PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-)
-target_link_libraries(greedy_solver
-        PRIVATE
-        common
-)
-set_target_properties(greedy_solver PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin
-)
-
 # —————— Tests ——————
 enable_testing()
 
@@ -78,3 +69,19 @@ target_include_directories(test_graph
         ${PROJECT_SOURCE_DIR}/include
 )
 add_test(NAME GraphTest COMMAND test_graph)
+
+add_executable(test_greedy_manual
+        test/test_greedy_manual.cpp
+        src/generator/io.cpp
+)
+
+target_include_directories(test_greedy_manual PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+)
+
+target_link_libraries(test_greedy_manual PRIVATE
+        common
+        greedy_solver
+)
+
+add_test(NAME GreedyTest COMMAND test_greedy_manual)

--- a/include/common/dijkstra.hpp
+++ b/include/common/dijkstra.hpp
@@ -5,8 +5,9 @@
 #ifndef DIJKSTRA_HPP
 #define DIJKSTRA_HPP
 #include <vector>
+#include <limits>
 
-#include "graph.hpp"
+#include "../graph.hpp"
 
 constexpr int INF = std::numeric_limits<int>::max();
 

--- a/include/common/dijkstra.hpp
+++ b/include/common/dijkstra.hpp
@@ -7,9 +7,15 @@
 #include <vector>
 #include <limits>
 
-#include "../graph.hpp"
+#include "graph.hpp"
 
 constexpr int INF = std::numeric_limits<int>::max();
+
+int findClosestUnvisited (const std::vector<int>& candidates, const std::vector<int>& dist);
+
+std::vector<int> reconstructPath (int target, const std::vector<int>& prev);
+
+std::vector<int> getUnvisited (const std::vector<char>& visited);
 
 std::vector<int> dijkstraPath(const graph::Graph& g, int src, int dest);
 
@@ -19,7 +25,6 @@ std::pair<std::vector<int>, std::vector<int>> dijkstraAll (const graph::Graph& g
 
 std::pair<std::vector<int>, std::vector<int>> dijkstraAll (const graph::Graph& g, int src, const std::vector<char>& visited);
 
-void finishRemaining (std::vector<int>& path, const graph::Graph& g,
-                        std::vector<char>& visited, double finish_ratio = 1.0);
+void finishRemaining (std::vector<int>& path, const graph::Graph& g, int& visited_count, std::vector<char>& visited);
 
 #endif //DIJKSTRA_HPP

--- a/include/common/graph.hpp
+++ b/include/common/graph.hpp
@@ -32,9 +32,9 @@ namespace graph {
 
         [[nodiscard]] int size() const;
 
-        [[nodiscard]] int Graph::weight(int u, int dest) const;
+        [[nodiscard]] int weight(int u, int dest) const;
 
-        [[nodiscard]] bool Graph::hasEdge(int u, int dest) const;
+        [[nodiscard]] bool hasEdge(int u, int dest) const;
         };
     };
 

--- a/include/dijkstra.hpp
+++ b/include/dijkstra.hpp
@@ -8,6 +8,7 @@
 
 #include "graph.hpp"
 
+constexpr int INF = std::numeric_limits<int>::max();
 
 std::vector<int> dijkstraPath(const graph::Graph& g, int src, int dest);
 

--- a/include/dijkstra.hpp
+++ b/include/dijkstra.hpp
@@ -9,6 +9,15 @@
 #include "graph.hpp"
 
 
-std::vector<int> dijkstraPath (const graph::Graph& g, int src, int dest, const std::vector<bool>& visited);
+std::vector<int> dijkstraPath(const graph::Graph& g, int src, int dest);
+
+std::vector<int> dijkstraPath (const graph::Graph& g, int src, int dest, const std::vector<char>& visited);
+
+std::pair<std::vector<int>, std::vector<int>> dijkstraAll (const graph::Graph& g, int src);
+
+std::pair<std::vector<int>, std::vector<int>> dijkstraAll (const graph::Graph& g, int src, const std::vector<char>& visited);
+
+void finishRemaining (std::vector<int>& path, const graph::Graph& g,
+                        std::vector<char>& visited, double finish_ratio = 1.0);
 
 #endif //DIJKSTRA_HPP

--- a/include/generator/io.hpp
+++ b/include/generator/io.hpp
@@ -12,6 +12,8 @@ namespace io {
 
     void readFromFile(const std::string& filename, std::string& main_sequence);
 
+    void readSpectrumFromFile(const std::string& filename, int& n, int& k, int& negErr, int& posErr, std::vector<std::string>& spectrum);
+
     void writeToFileSpectrum(const vs& spectrum, int n, int k, int negative_errors,
                                 int positive_errors, const std::string& filepath);
 

--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -33,6 +33,8 @@ namespace graph {
         [[nodiscard]] int size() const;
 
         [[nodiscard]] int Graph::weight(int u, int dest) const;
+
+        [[nodiscard]] bool Graph::hasEdge(int u, int dest) const;
         };
     };
 

--- a/include/greedy-solver/greedy.hpp
+++ b/include/greedy-solver/greedy.hpp
@@ -8,16 +8,11 @@
 
 #include "graph.hpp"
 
-static constexpr int NUM_CANDIDATES = 5;
-static constexpr double TOLERANCE = 1.2;
-static constexpr double FINISH_RATIO = 0.95;
-
-
 std::vector<int> greedySolver(const graph::Graph& g, int start);
 
-int pathWeight(const graph::Graph& g, const std::vector<int>& path_vector);
+int computePathWeight(const graph::Graph& g, const std::vector<int>& path_vector);
 
-std::vector<int> unvisitedNeighbors(const graph::Graph& g, int u, int weight, const std::vector<bool>& visited);
+std::vector<int> unvisitedNeighbors(const graph::Graph& g, int u, int weight, const std::vector<char>& visited);
 
 
 #endif //GREEDY_HPP

--- a/include/greedy-solver/greedy.hpp
+++ b/include/greedy-solver/greedy.hpp
@@ -6,13 +6,16 @@
 #define GREEDY_HPP
 #include <vector>
 
-#include "graph.hpp"
+#include "common/graph.hpp"
 
 std::vector<int> greedySolver(const graph::Graph& g, int start);
 
 int computePathWeight(const graph::Graph& g, const std::vector<int>& path_vector);
 
-std::vector<int> unvisitedNeighbors(const graph::Graph& g, int u, int weight, const std::vector<char>& visited);
+void selectCandidates(const graph::Graph& g, int current, int weight, std::vector<int>& candidates, const std::vector<char>& visited);
 
+int stepBack (std::vector<int>& path, int& dead_end);
+
+bool isDeadEnd (const graph::Graph& g, int u);
 
 #endif //GREEDY_HPP

--- a/src/common/dijkstra.cpp
+++ b/src/common/dijkstra.cpp
@@ -4,17 +4,16 @@
 #include "dijkstra.hpp"
 
 #include <algorithm>
-#include <limits>
 #include <queue>
 
 #include "graph.hpp"
 
 using Pair = std::pair<int, int>;
 
-constexpr int INF = std::numeric_limits<int>::max();
-
 //Dijkstra algorithm including visited nodes
 std::vector<int> dijkstraPath(const graph::Graph& g, int src, int dest) {
+
+    if (src == dest) return {src};
 
     int n = g.size();
     std::vector<int> dist (n, INF);
@@ -49,6 +48,8 @@ std::vector<int> dijkstraPath(const graph::Graph& g, int src, int dest) {
 
 //Dijkstra algorithm through unvisited nodes
 std::vector<int> dijkstraPath (const graph::Graph& g, int src, int dest, const std::vector<char>& visited) {
+
+    if (src == dest) return {src};
 
     int n = g.size();
     std::vector<int> dist (n, INF);
@@ -148,6 +149,7 @@ void finishRemaining (std::vector<int>& path, const graph::Graph& g,
         int visited_count = static_cast<int>(std::ranges::count(visited, true));
         if (static_cast<double> (visited_count) / n >= finish_ratio) break;
 
+        //try to find path through all remaining unvisited nodes only
         auto [dist, prev] = dijkstraAll(g, current, visited);
 
         int best_u = -1;
@@ -159,6 +161,7 @@ void finishRemaining (std::vector<int>& path, const graph::Graph& g,
             }
         }
 
+        //can't find path through unvisited nodes - run Dijkstra algorithm including visited nodes
         if (best_u == -1 || best_dist == INF) {
             std::tie(dist, prev) = dijkstraAll(g, current);
             for (int u : remaining) {

--- a/src/common/dijkstra.cpp
+++ b/src/common/dijkstra.cpp
@@ -11,10 +11,13 @@
 
 using Pair = std::pair<int, int>;
 
-std::vector<int> dijkstraPath (const graph::Graph& g, int src, int dest, const std::vector<bool>& visited) {
+constexpr int INF = std::numeric_limits<int>::max();
+
+//Dijkstra algorithm including visited nodes
+std::vector<int> dijkstraPath(const graph::Graph& g, int src, int dest) {
 
     int n = g.size();
-    std::vector<int> dist (n, std::numeric_limits<int>::max());
+    std::vector<int> dist (n, INF);
     std::vector<int> prev (n, -1);
 
     std::priority_queue<Pair, std::vector<Pair>, std::greater<>> pq;
@@ -22,23 +25,18 @@ std::vector<int> dijkstraPath (const graph::Graph& g, int src, int dest, const s
     pq.emplace(dist[src], src);
 
     while (!pq.empty()) {
-        auto [d, u] = pq.top();
-        pq.pop();
-
+        auto [d, u] = pq.top(); pq.pop();
         if (d > dist[u]) continue;
-        if (u == dest) break;
 
         for (auto [v, w] : g.neighbors(u)) {
-            if (visited[v]) continue;
-            int nd = d + w; //new distance
-            if (nd < dist[v]) {
-                dist[v] = nd;
+            if (dist[u] + w < dist[v]) {
+                dist[v] = dist[u] + w;
                 prev[v] = u;
-                pq.emplace (nd, v);
+                pq.emplace(dist[v], v);
             }
         }
     }
-    if (dist[dest] == std::numeric_limits<int>::max()) {
+    if (dist[dest] == INF) {
         return {};
     }
     std::vector<int> path;
@@ -47,4 +45,143 @@ std::vector<int> dijkstraPath (const graph::Graph& g, int src, int dest, const s
     }
     std::ranges::reverse(path);
     return path;
+}
+
+//Dijkstra algorithm through unvisited nodes
+std::vector<int> dijkstraPath (const graph::Graph& g, int src, int dest, const std::vector<char>& visited) {
+
+    int n = g.size();
+    std::vector<int> dist (n, INF);
+    std::vector<int> prev (n, -1);
+
+    std::priority_queue<Pair, std::vector<Pair>, std::greater<>> pq;
+    dist[src] = 0;
+    pq.emplace(dist[src], src);
+
+    while (!pq.empty()) {
+        auto [d, u] = pq.top(); pq.pop();
+        if (d > dist[u]) continue;
+
+        for (auto [v, w] : g.neighbors(u)) {
+            if (visited[v]) continue;
+            if (dist[u] + w < dist[v]) {
+                dist[v] = dist[u] + w;
+                prev[v] = u;
+                pq.emplace(dist[v], v);
+            }
+        }
+    }
+    if (dist[dest] == INF) {
+        return {};
+    }
+    std::vector<int> path;
+    for (int at = dest; at != -1; at = prev[at]) {
+        path.push_back(at);
+    }
+    std::ranges::reverse(path);
+    return path;
+}
+
+std::pair<std::vector<int>, std::vector<int>> dijkstraAll (const graph::Graph& g, int src) {
+
+    int n = g.size();
+    std::vector<int> dist (n, INF);
+    std::vector<int> prev (n, -1);
+
+    std::priority_queue<Pair, std::vector<Pair>, std::greater<>> pq;
+    dist[src] = 0;
+    pq.emplace(dist[src], src);
+    while (!pq.empty()) {
+        auto [d, u] = pq.top(); pq.pop();
+        if (d > dist[u]) continue;
+
+        for (auto [v, w] : g.neighbors(u)) {
+            if (dist[u] + w < dist[v]) {
+                dist[v] = dist[u] + w;
+                prev[v] = u;
+                pq.emplace(dist[v], v);
+            }
+        }
+    }
+    return {dist, prev};
+}
+
+std::pair<std::vector<int>, std::vector<int>> dijkstraAll (const graph::Graph& g, int src, const std::vector<char>& visited) {
+
+    int n = g.size();
+    std::vector<int> dist (n, INF);
+    std::vector<int> prev (n, -1);
+
+    std::priority_queue<Pair, std::vector<Pair>, std::greater<>> pq;
+    dist[src] = 0;
+    pq.emplace(dist[src], src);
+    while (!pq.empty()) {
+        auto [d, u] = pq.top(); pq.pop();
+        if (d > dist[u]) continue;
+
+        for (auto [v, w] : g.neighbors(u)) {
+            if (visited[v]) continue;
+            if (dist[u] + w < dist[v]) {
+                dist[v] = dist[u] + w;
+                prev[v] = u;
+                pq.emplace(dist[v], v);
+            }
+        }
+    }
+    return {dist, prev};
+}
+
+
+void finishRemaining (std::vector<int>& path, const graph::Graph& g,
+                        std::vector<char>& visited, double finish_ratio) {
+
+    int n = g.size();
+    int current = path.back();
+
+    while (true) {
+        std::vector<int> remaining;
+        for (int i = 0; i < n; ++i)
+            if (!visited[i])
+                remaining.push_back(i);
+        if (remaining.empty()) break;
+
+        int visited_count = static_cast<int>(std::ranges::count(visited, true));
+        if (static_cast<double> (visited_count) / n >= finish_ratio) break;
+
+        auto [dist, prev] = dijkstraAll(g, current, visited);
+
+        int best_u = -1;
+        int best_dist = INF;
+        for (int u : remaining) {
+            if (dist[u] < best_dist) {
+                best_dist = dist[u];
+                best_u = u;
+            }
+        }
+
+        if (best_u == -1 || best_dist == INF) {
+            std::tie(dist, prev) = dijkstraAll(g, current);
+            for (int u : remaining) {
+                if (dist[u] < best_dist) {
+                    best_dist = dist[u];
+                    best_u = u;
+                }
+            }
+        }
+        if (best_u == -1 || best_dist == INF) break;
+
+        std::vector<int> subpath;
+        for (int v = best_u; v != -1; v = prev[v]) {
+            subpath.push_back(v);
+        }
+        std::ranges::reverse(subpath);
+
+        for (size_t i = 1; i < subpath.size(); ++i) {
+            int v = subpath[i];
+            path.push_back(v);
+            visited[v] = true;
+        }
+
+        current = path.back();
+    }
 }

--- a/src/common/graph.cpp
+++ b/src/common/graph.cpp
@@ -3,6 +3,8 @@
 //
 
 #include "graph.hpp"
+
+#include <algorithm>
 #include <vector>
 #include <string>
 #include <string_view>
@@ -70,5 +72,11 @@ namespace graph {
             if (dest == v) return w;
         }
         return 0;
+    }
+
+    bool Graph::hasEdge(int u, int dest) const {
+        return std::ranges::any_of(adj_[u], [dest](const auto& edge) {
+            return edge.first == dest;
+        });
     }
 }

--- a/src/common/graph.cpp
+++ b/src/common/graph.cpp
@@ -2,7 +2,7 @@
 // Created by maciej on 22.04.25.
 //
 
-#include "graph.hpp"
+#include "common/graph.hpp"
 
 #include <algorithm>
 #include <vector>

--- a/src/generator/io.cpp
+++ b/src/generator/io.cpp
@@ -21,7 +21,7 @@ namespace io {
         file.close();
     }
 
-    void io::readSpectrumFromFile(const std::string& filename, int& n, int& k, int& negErr, int& posErr, std::vector<std::string>& spectrum) {
+    void readSpectrumFromFile(const std::string& filename, int& n, int& k, int& negErr, int& posErr, std::vector<std::string>& spectrum) {
         std::ifstream file(filename);
         if (!file.is_open()) {
             throw std::runtime_error("Nie mozna otworzyc pliku z danymi spektrum: " + filename);

--- a/src/generator/io.cpp
+++ b/src/generator/io.cpp
@@ -21,6 +21,22 @@ namespace io {
         file.close();
     }
 
+    void io::readSpectrumFromFile(const std::string& filename, int& n, int& k, int& negErr, int& posErr, std::vector<std::string>& spectrum) {
+        std::ifstream file(filename);
+        if (!file.is_open()) {
+            throw std::runtime_error("Nie mozna otworzyc pliku z danymi spektrum: " + filename);
+        }
+
+        file >> n >> k >> negErr >> posErr;
+
+        std::string line;
+        while (file >> line) {
+            spectrum.emplace_back(line);
+        }
+
+        file.close();
+    }
+
     void writeToFileSequence(const std::string& main_sequence, const std::string& filepath) {
         std::string filename = filepath + std::to_string(main_sequence.size()) + "_seq.txt";
         std::ofstream file2(filename);

--- a/src/greedy-solver/greedy.cpp
+++ b/src/greedy-solver/greedy.cpp
@@ -5,13 +5,15 @@
 #include "greedy-solver/greedy.hpp"
 
 #include <algorithm>
+#include <iostream>
 #include <random>
 #include <ranges>
 
-#include "graph.hpp"
-#include "dijkstra.hpp"
+#include "common/graph.hpp"
+#include "common/dijkstra.hpp"
 
-static constexpr int NUM_CANDIDATES = 5;
+static constexpr int NUM_CANDIDATES = 8;
+//static constexpr int NUM_CANDIDATES_RESELECT = 5;
 static constexpr double TOLERANCE = 1.2;
 static constexpr double FINISH_RATIO = 0.95;
 
@@ -26,23 +28,70 @@ std::vector<int> greedySolver(const Graph& g, int start) {
     path.reserve(path_size);
     int current = start;
     visited[current] = true;
+    int visited_count = 1;
     path.emplace_back(current);
     std::mt19937_64 rng(std::random_device{}());
+    int dead_end = -1;
 
     while (true) {
-        auto next1 = unvisitedNeighbors(g, current, 1, visited);
-        if (!next1.empty()) {
-            current = next1.front();
-            visited[current] = true;
-            path.emplace_back(current);
+        if (current == -1) {
+            std::cout << "StepBack failed: cannot go back further.\n";
+            break; // or return path;
+        }
+        //Choose edges with weight 1
+        bool moved = true;
+        while (moved) {
+            moved = false;
+            for (auto [v, w] : g.neighbors(current)) {
+                if (!visited[v] && w == 1) {
+                    current = v;
+                    visited[current] = true;
+                    ++visited_count;
+                    path.emplace_back(current);
+                    moved = true;
+                    break;
+                }
+            }
+        }
+
+        if (dead_end != -1) {
+            visited[dead_end] = false;
+            --visited_count;
+            dead_end = -1;
+        }
+        if (isDeadEnd(g, current) && (1.0 * visited_count / n) < FINISH_RATIO) {
+            current = stepBack(path, dead_end);
             continue;
         }
+
+        std::cout << "\n--- Debug Check ---\n";
+        std::cout << "Current vertex: " << current << "\n";
+
+        std::cout << "Visited[10] = " << static_cast<int>(visited[10]) << "\n";
+        std::cout << "Neighbors of 5: ";
+        for (auto [v, w] : g.neighbors(5)) {
+            std::cout << "(" << v << ", " << w << ")";
+            if (v == 10) std::cout << " <-- target!";
+            std::cout << " ";
+        }
+        std::cout << "\n";
+
+        std::cout << "Current neighbors (of " << current << "): ";
+        for (auto [v, w] : g.neighbors(current)) {
+            std::cout << "(" << v << ", " << w << ") ";
+        }
+        std::cout << "\n";
+
+        std::cout << "--- End Debug ---\n\n";
+
+
+        //fallback: no weight 1 edge from current node - choose candidates from neighbors
+        //that has w1 edge to farther unvisited nodes
         std::vector<int> candidates;
         candidates.reserve(NUM_CANDIDATES * 2);
-        for (auto wgt : {2, 3}) {
-            candidates = std::move(unvisitedNeighbors(g, current, wgt, visited));
-            if (candidates.size() >= NUM_CANDIDATES) break;
-        }
+        selectCandidates(g, current, 1, candidates, visited);
+
+        //randomly add candidates from other unvisited nodes that has weight 1 edge to other unvisited node
         if (candidates.size() < NUM_CANDIDATES) {
             std::vector<int> pool;
             pool.reserve(n);
@@ -60,8 +109,12 @@ std::vector<int> greedySolver(const Graph& g, int start) {
                 candidates.emplace_back(u);
             }
         }
-        if (candidates.empty()) break;
+        /*if (candidates.empty()) {
+            std::cout << "Debug: Empty candidates! Break algorithm loop 1" << std::endl; //debug
+            break;
+        }*/
 
+        //prefer candidates from neighbors of the current node
         int chosen = -1;
         for (int u : candidates) {
             for (auto v: g.neighbors(current) | std::views::keys) {
@@ -70,11 +123,18 @@ std::vector<int> greedySolver(const Graph& g, int start) {
                     break;
                 }
             }
-            if (chosen != -1) break;
+            if (chosen != -1) {
+                std::cout << "Debug: Chosen vertex " << chosen << " at " << current << std::endl;
+                path.emplace_back(chosen);
+                break;
+            }
         }
+        //no candidates from neighbors selected.
+        //Use Dijkstra's algorithm to select nearest candidate (subpath with the least weight), unvisited nodes only
         std::vector<int> subpath;
         subpath.reserve(n / 10);
         if (chosen == -1) {
+            std::cout << "Dijkstra through unvisited. Current: " << current << std::endl;
             int best_u = -1;
             int best_dist = INF;
             for (int u : candidates) {
@@ -83,22 +143,46 @@ std::vector<int> greedySolver(const Graph& g, int start) {
                 if (!sp.empty() && dist < best_dist) {
                     best_u = u;
                     best_dist = dist;
+                    std::cout << "Debug: Chosen unvisited vertex: " << best_u << " distance: " << best_dist << std::endl;
                 }
             }
-            if (best_u == -1) break; //no path
+            //no possible path via unvisited nodes only. Allow visited nodes.
+            if (best_u == -1 || best_dist == INF) {
+                std::cout << "Dijkstra through visited. Current: " << current << std::endl;
+
+                for (int u : candidates) {
+                    auto sp = dijkstraPath(g, current, u);
+                    int dist = computePathWeight(g, sp);
+                    if (!sp.empty() && dist < best_dist) {
+                        best_u = u;
+                        best_dist = dist;
+                        std::cout << "Debug: Chosen (un)visited vertex: " << best_u << " distance: " << best_dist << std::endl;
+                    }
+                }
+            }
+            if ((best_u == -1 || best_dist == INF) && (1.0 * visited_count / n) >= FINISH_RATIO) {
+                //still no path. Try to finish the sequence with DijkstraAll.
+                //Consider reselecting neighbors few times before finishing...???
+                std::cout << "Debug: no path found to candidates!" << std::endl;
+                std::cout << "Trying to finish the sequence with finishRemaining..." << std::endl;
+                finishRemaining(path, g, visited_count, visited);
+                break;
+            }
             subpath = dijkstraPath(g, current, best_u, visited);
             chosen = best_u;
         }
-        for (int i = 1; i < subpath.size(); ++i) {
+        for (size_t i = 1; i < subpath.size(); ++i) {
             int u = subpath[i];
             visited[u] = true;
+            ++visited_count;
             path.emplace_back(u);
         }
         current = chosen;
 
-        int visited_count = static_cast<int>(std::ranges::count(visited, true));
+        visited_count = static_cast<int>(std::ranges::count(visited, true));
+
         if (1.0 * visited_count / n >= FINISH_RATIO) {
-            finishRemaining(path, g, visited, FINISH_RATIO);
+            finishRemaining(path, g, visited_count, visited);
             break;
         }
     }
@@ -106,22 +190,44 @@ std::vector<int> greedySolver(const Graph& g, int start) {
     return path;
 }
 
-std::vector<int> unvisitedNeighbors(const Graph& g, int u, int weight, const std::vector<char>& visited) {
-    std::vector<int> unv_neighbors;
-    for (auto [v, w] : g.neighbors(u)) {
-        if (!visited[v] && w == weight) unv_neighbors.push_back(v);
-    }
-    return unv_neighbors;
-}
-
 int computePathWeight(const Graph& g, const std::vector<int>& path_vector) {
     if (path_vector.size() < 2) return INF;
     int path_weight = 0;
 
-    for (int i = 0; i + 1 < path_vector.size(); ++i) {
+    for (size_t i = 0; i + 1 < path_vector.size(); ++i) {
         int weight = g.weight(path_vector[i], path_vector[i + 1]);
         if (!weight) return INF;
         path_weight += weight;
     }
     return path_weight;
+}
+
+void selectCandidates(const Graph& g, int current, int weight, std::vector<int>& candidates, const std::vector<char>& visited) {
+    candidates.reserve(NUM_CANDIDATES * 2);
+    for (auto v1 : g.neighbors(current) | std::views::keys) {
+        for (auto [v2, w2] : g.neighbors(v1)) {
+            if (!visited[v2] && w2 == weight) {
+                candidates.emplace_back(v1);
+                break;
+            }
+        }
+    }
+}
+
+int stepBack (std::vector<int>& path, int& dead_end) {
+    if (path.size() < 2) {
+        // cant go back anymore
+        dead_end = -1;
+        return -1;
+    }
+    dead_end = path.back();
+    int previous_node = *(path.end() - 2);
+    path.pop_back();
+    std::cout << "Stepback! From " << dead_end << " to " << previous_node << std::endl;
+
+    return previous_node;
+}
+
+bool isDeadEnd (const Graph& g, int u) {
+    return g.neighbors(u).empty();
 }

--- a/test/test_graph.cpp
+++ b/test/test_graph.cpp
@@ -5,7 +5,7 @@
 #include <cassert>
 #include <vector>
 #include <string>
-#include "graph.hpp"
+#include "common/graph.hpp"
 
 int main() {
     std::vector<std::string> spec = {"ABCDE", "BCDEB", "CDEBA", "DEBAA"};

--- a/test/test_greedy_manual.cpp
+++ b/test/test_greedy_manual.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include "common/graph.hpp"
+#include "greedy-solver/greedy.hpp"
+#include "generator/io.hpp"
+
+void printPath(const std::vector<int>& path) {
+    std::cout << "Path: ";
+    for (int v : path) std::cout << v << " ";
+    std::cout << "\n";
+}
+
+void printCoverage(const std::vector<char>& visited) {
+    int total = static_cast<int>(visited.size());
+    int visited_count = 0;
+    for (char v : visited) if (v) ++visited_count;
+
+    std::cout << "Visited: " << visited_count << "/" << total
+              << " (" << 100.0 * visited_count / total << "%)\n";
+}
+
+int main() {
+    std::string filename = "../bin/500_10_0_0.txt";
+
+    int n, k, neg, pos;
+    std::vector<std::string> spectrum;
+
+    try {
+        io::readSpectrumFromFile(filename, n, k, neg, pos, spectrum);
+    } catch (const std::exception& e) {
+        std::cerr << "Błąd wczytywania pliku: " << e.what() << std::endl;
+        return 1;
+    }
+
+    graph::Graph g;
+    g.build(spectrum);
+
+    std::vector<int> path = greedySolver(g, 0);  // jaki będzie primer?
+
+    std::vector<char> visited(g.size(), false);
+    for (int v : path) visited[v] = true;
+
+    printPath(path);
+    std::cout << "Total weight: " << computePathWeight(g, path) << "\n";
+    printCoverage(visited);
+
+    return 0;
+}


### PR DESCRIPTION
This pull request introduces the first working draft of the greedy solver algorithm for SBH path reconstruction.

✔ Traverses weight-1 edges as primary path
✔ Selects candidates based on weight-2 and weight-3 edges
✔ Uses Dijkstra fallback when greedy traversal is not possible
✔ Adds finishRemaining() to complete the path toward Hamiltonian coverage
✔ Adds Graph::hasEdge() utility using std::ranges::any_of

🚧 This version still requires proper testing and validation.
Results have not yet been verified on real instances.

Suggestions and feedback are welcome.
